### PR TITLE
235 236 237

### DIFF
--- a/Vizzies/public_html/index.html
+++ b/Vizzies/public_html/index.html
@@ -29,7 +29,7 @@
 				<tr><td><a data-scroll href="#s2"><div id="links-anchor-link-2" class="links-anchor-link-empty links-anchor" title="News Coverage">&nbsp;</div></a></td></tr>
 				<tr><td><a data-scroll href="#s3"><div id="links-anchor-link-3" class="links-anchor-link-empty links-anchor" title="Reservoir Coverage">&nbsp;</div></a></td></tr>
 				<tr><td><a data-scroll href="#s4"><div id="links-anchor-link-4" class="links-anchor-link-empty links-anchor" title="Drought Impacts">&nbsp;</div></a></td></tr>
-				<tr><td><a data-scroll href="#s5"><div id="links-anchor-link-5" class="links-anchor-link-empty links-anchor" title="Snowpack/Consumptive Use">&nbsp;</div></a></td></tr>
+				<tr><td><a data-scroll href="#s5"><div id="links-anchor-link-5" class="links-anchor-link-empty links-anchor" title="Snowpack/Freshwater Withdrawals">&nbsp;</div></a></td></tr>
 				<tr><td><a data-scroll href="#s6"><div id="links-anchor-link-6" class="links-anchor-link-empty links-anchor" title="Food Prices">&nbsp;</div></a></td></tr>
 				<tr><td><a data-scroll href="#s7"><div id="links-anchor-link-7" class="links-anchor-link-empty links-anchor" title="Credits">&nbsp;</div></a></td></tr>
 			</table>
@@ -147,6 +147,15 @@
 					</div>
 				</div>
 			</div>
+            
+            <div class="spacer s0"></div>
+            <div id="sidebar-trigger"></div>
+            <div id="sidebar-pin">
+				<div class="right snowpack-container">
+					<p>Irrigation, public supply, and domestic freshwater withdrawals are the biggest uses of freshwater in California (<a class="white" href="#ref1">1</a>)</p>
+				</div>
+			</div>
+            
 			<div class="spacer s0"></div>
 			<div id="usage-pie-trigger"></div>
 			<div id="usage-pie-pin">
@@ -169,7 +178,7 @@
 				<div class="right higher" style="z-index:99999">
 					<h2>Drought and Food Prices</h2>
 
-					<p>Of consumptive water use, agriculture represents 74% of freshwater use (<a class="white"  href="#ref1">1</a>).</p>
+					<p>Agriculture represents the largest fraction of freshwater withdrawals(<a class="white"  href="#ref1">1</a>).</p>
 					<p>For the first time in history, some agricultural areas are not receiving any water for irrigation which is resulting in devastation of historically productive areas. The agricultural output for the state could fall by $3.5 billion this year (<a class="white"  href="#ref3">3</a>).</p>
 				</div>
 				<div id="ag-prices" class='higher'>

--- a/Vizzies/public_html/js/main.js
+++ b/Vizzies/public_html/js/main.js
@@ -183,6 +183,12 @@ $(document).ready(function () {
 			panAndZoom(caliLeftCenter, caliZoom);
 		})
 		.addTo(controller);
+	new ScrollScene({triggerElement: "#sidebar-trigger", duration: 2500})
+		.setPin("#sidebar-pin")
+		.on("enter", function (e) {
+			panAndZoom(caliLeftCenter, caliZoom);
+		})
+		.addTo(controller);
 	new ScrollScene({triggerElement: "#usage-pie-trigger", duration: 2500})
 		.setPin("#usage-pie-pin")
 		.on("enter", function (e) {


### PR DESCRIPTION
235: Instead of consumptive use, change to freshwater withdrawals like the pie chart title

236: Add a sidebar with text between the snowpack and withdrawal figures that reads "Irrigation, public supply, and domestic freshwater withdrawals are the biggest uses of freshwater in California (1)." with the (1) linked to the Kenny paper, reference #1.

237: Instead of "Of consumptive water use, agriculture represents 74% of freshwater use (1).", should read "Agriculture represents the largest fraction of freshwater withdrawals (1)."
