### PR TITLE
hyperlink to usgs.gov

### DIFF
--- a/Vizzies/public_html/index.html
+++ b/Vizzies/public_html/index.html
@@ -86,7 +86,7 @@ var tooltip;
     
     <div id="usgsheader">
     
-    	<img src="usgslogo.jpg" alt="usgslogo"/>
+    	<a href="http://www.usgs.gov/" target="_blank"><img src="usgslogo.jpg" alt="usgslogo"/></a>
         <img src="banner.png" alt="banner"/>
         
         <div id="headernav">


### PR DESCRIPTION
USGS logo is hyperlinked to usgs.gov now. A woot woot.
